### PR TITLE
chore: rename resultIndex to result-index

### DIFF
--- a/pkg/uncalled/.uncalled.yaml
+++ b/pkg/uncalled/.uncalled.yaml
@@ -14,5 +14,5 @@ rules:
           pointer: false
     expect:
       method: .Err
-      resultIndex: 0
+      result-index: 0
       args: []

--- a/pkg/uncalled/config.go
+++ b/pkg/uncalled/config.go
@@ -32,6 +32,7 @@ type Rule struct {
 	types map[string]struct{}
 }
 
+// expects returns the expected string based on ident.
 func (r Rule) expects(ident string) string {
 	if ident == "" {
 		ident = strings.TrimLeft(r.Call.Results[r.Expect.ResultIndex].Type, ".")
@@ -158,7 +159,7 @@ func (r Result) name(pkg string) string {
 // Expect is the expected call for a Rule.
 type Expect struct {
 	Method      string
-	ResultIndex int `yaml:"resultIndex" mapstructure:"resultIndex"`
+	ResultIndex int `yaml:"result-index" mapstructure:"result-index"`
 	Args        []string
 }
 


### PR DESCRIPTION
Rename resultIndex in config output to result-index to match the standard in golangci-lint.