### PR TITLE
feat: http response body close

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ test/bad.go:10:2: rows.Err() must be called
 ```
 
 Or run it directly.
+
 ```bash
 uncalled ./...
 # github.com/stevenh/go-uncalled/test
@@ -48,7 +49,6 @@ Its default config checks calls to [database/sql](https://pkg.go.dev/database/sq
 - [sql.Rows.NextResultSet](https://pkg.go.dev/database/sql#Rows.NextResultSet)
 
 The following code is wrong, as it should check [Rows.Err()](https://pkg.go.dev/database/sql#Rows.Err) after [Rows.Next()](https://pkg.go.dev/database/sql#Rows.Next) returns false.
-
 
 ```go
 rows, err := db.Query("select id from tb")

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,14 @@ module github.com/stevenh/go-uncalled
 go 1.19
 
 require (
+	github.com/rs/zerolog v1.28.0
 	golang.org/x/tools v0.2.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,17 @@
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
+github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
 golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=

--- a/pkg/uncalled/.uncalled.yaml
+++ b/pkg/uncalled/.uncalled.yaml
@@ -1,5 +1,5 @@
 rules:
-  - name: sql.Rows
+  - name: sql.Rows.Err
     disabled: false
     severity: warning
     packages:
@@ -14,5 +14,21 @@ rules:
           pointer: false
     expect:
       method: .Err
+      result-index: 0
+      args: []
+  - name: http.Response.Body.Close
+    disabled: false
+    severity: warning
+    packages:
+      - net/http
+    call:
+      methods: []
+      results:
+        - type: .Response
+          pointer: true
+        - type: error
+          pointer: false
+    expect:
+      method: .Body.Close
       result-index: 0
       args: []

--- a/pkg/uncalled/analyzer_test.go
+++ b/pkg/uncalled/analyzer_test.go
@@ -9,5 +9,13 @@ import (
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, uncalled.NewAnalyzer(), "a")
+	analysistest.Run(
+		t,
+		testdata,
+		uncalled.NewAnalyzer(
+			uncalled.TestWriter(t),
+		),
+		"./database/sql/rows/err",
+		"./net/http/request/body/close",
+	)
 }

--- a/pkg/uncalled/loader.go
+++ b/pkg/uncalled/loader.go
@@ -1,0 +1,45 @@
+package uncalled
+
+import (
+	"sync/atomic"
+
+	"golang.org/x/tools/go/analysis"
+	"gopkg.in/yaml.v3"
+)
+
+// loader creates a new analyser to process each call to its
+// run method, this is needed as analysistest calls run in
+// parallel and as analyzer relies on its internal state this
+// resulted in random panics.
+type loader struct {
+	cfg     *Config
+	options []Option
+	log     log
+	id      atomic.Int32
+}
+
+// run creates an analyzer and calls run on it.
+func (l *loader) run(pass *analysis.Pass) (interface{}, error) {
+	a := &analyzer{
+		cfg:     l.cfg,
+		options: l.options,
+		log: l.log.
+			With().
+			Int32("id", l.id.Add(1)).
+			Logger(),
+	}
+
+	return a.run(pass)
+}
+
+// String implements flag.Value.
+func (l *loader) String() string {
+	b, _ := yaml.Marshal(l.cfg)
+	return string(b)
+}
+
+// String implements flag.Value.
+func (l *loader) Set(file string) error {
+	l.cfg = &Config{}
+	return l.cfg.load(file)
+}

--- a/pkg/uncalled/log.go
+++ b/pkg/uncalled/log.go
@@ -1,0 +1,41 @@
+package uncalled
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+)
+
+// log is a command line configurable logger.
+type log struct {
+	zerolog.Logger
+}
+
+// String implements flag.Value.
+func (l *log) String() string {
+	return l.GetLevel().String()
+}
+
+// String implements flag.Value.
+func (l *log) Set(val string) error {
+	if val == "true" {
+		if lvl := l.Logger.GetLevel(); lvl > zerolog.TraceLevel {
+			l.Logger = l.Level(lvl - 1)
+		}
+		return nil
+	}
+
+	lvl, err := zerolog.ParseLevel(val)
+	if err != nil {
+		return fmt.Errorf("set log level: %w", err)
+	}
+
+	l.Logger = l.Level(lvl)
+
+	return nil
+}
+
+// IsBoolFlag is an optional method which indicates this is bool flag.
+func (l log) IsBoolFlag() bool {
+	return true
+}

--- a/pkg/uncalled/testdata/database/sql/rows/err/called.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/called.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
@@ -6,13 +6,13 @@ import (
 	"io/ioutil"
 )
 
-func CheckedAssign(db *sql.DB) {
+func Called(db *sql.DB) {
 	rows, _ := db.Query("select id from tb")
 	for rows.Next() {
 		// Handle row.
 	}
-	if err := rows.Err(); err != nil {
+	if rows.Err() != nil {
 		// Handle error.
-		fmt.Fprintln(ioutil.Discard, err)
+		fmt.Fprintln(ioutil.Discard, "error")
 	}
 }

--- a/pkg/uncalled/testdata/database/sql/rows/err/called_assign.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/called_assign.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
@@ -6,13 +6,13 @@ import (
 	"io/ioutil"
 )
 
-func Checked(db *sql.DB) {
+func CalledAssign(db *sql.DB) {
 	rows, _ := db.Query("select id from tb")
 	for rows.Next() {
 		// Handle row.
 	}
-	if rows.Err() != nil {
+	if err := rows.Err(); err != nil {
 		// Handle error.
-		fmt.Fprintln(ioutil.Discard, "error")
+		fmt.Fprintln(ioutil.Discard, err)
 	}
 }

--- a/pkg/uncalled/testdata/database/sql/rows/err/called_def.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/called_def.go
@@ -1,10 +1,10 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
 )
 
-func CheckedDefer(db *sql.DB) {
+func CalledDefer(db *sql.DB) {
 	rows, _ := db.Query("select id from tb")
 	defer func() {
 		_ = rows.Err()

--- a/pkg/uncalled/testdata/database/sql/rows/err/called_func.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/called_func.go
@@ -1,10 +1,10 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
 )
 
-func CheckedFunc(db *sql.DB) {
+func CalledFunc(db *sql.DB) {
 	rows, _ := db.Query("")
 	resCloser, n := func(rs *sql.Rows, other int) {
 		_ = rs.Err()

--- a/pkg/uncalled/testdata/database/sql/rows/err/called_generics.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/called_generics.go
@@ -1,6 +1,6 @@
 //go:build go1.18
 
-package a
+package uncalled_test
 
 import (
 	"database/sql"
@@ -8,9 +8,9 @@ import (
 	"io/ioutil"
 )
 
-var _ = CheckedGeneric[int64]
+var _ = CalledGeneric[int64]
 
-func CheckedGeneric[T ~int64](db *sql.DB, a T) {
+func CalledGeneric[T ~int64](db *sql.DB, a T) {
 	rows, _ := db.Query("select id from tb")
 	for rows.Next() {
 		// Handle row.
@@ -21,7 +21,7 @@ func CheckedGeneric[T ~int64](db *sql.DB, a T) {
 	}
 }
 
-func CheckedGenericAssign[T ~int64](db *sql.DB, a T) {
+func CalledGenericAssign[T ~int64](db *sql.DB, a T) {
 	rows, _ := db.Query("select id from tb")
 	for rows.Next() {
 		// Handle row.
@@ -32,7 +32,7 @@ func CheckedGenericAssign[T ~int64](db *sql.DB, a T) {
 	}
 }
 
-func CheckedGenericDefer[T ~int64](db *sql.DB, a T) {
+func CalledGenericDefer[T ~int64](db *sql.DB, a T) {
 	rows, _ := db.Query("select id from tb")
 	for rows.Next() {
 		// Handle row.

--- a/pkg/uncalled/testdata/database/sql/rows/err/called_inline.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/called_inline.go
@@ -1,10 +1,10 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
 )
 
-func CheckedInlineFunc(db *sql.DB) {
+func CalledInlineFunc(db *sql.DB) {
 	_ = func(db *sql.DB) {
 		rows, _ := db.Query("") // OK
 		_ = rows.Err()

--- a/pkg/uncalled/testdata/database/sql/rows/err/called_vars.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/called_vars.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-func CheckedVars(db *sql.DB) {
+func CalledVars(db *sql.DB) {
 	rows, err := db.Query("") // OK
 	if err != nil {
 		// handle error

--- a/pkg/uncalled/testdata/database/sql/rows/err/not_called.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/not_called.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 )
 
-func RowsErrNotChecked(db *sql.DB) {
+func RowsErrNotCalled(db *sql.DB) {
 	rows, _ := db.Query("select id from tb") // want "rows.Err\\(\\) must be called"
 	for rows.Next() {
 		// Handle row.

--- a/pkg/uncalled/testdata/database/sql/rows/err/not_called_close.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/not_called_close.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"

--- a/pkg/uncalled/testdata/database/sql/rows/err/not_called_genrics.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/not_called_genrics.go
@@ -1,21 +1,21 @@
 //go:build go1.18
 
-package a
+package uncalled_test
 
 import (
 	"database/sql"
 )
 
-var _ = NotCheckedGeneric[int64]
+var _ = NotCalledGeneric[int64]
 
-func NotCheckedGeneric[T ~int64](db *sql.DB, a T) {
+func NotCalledGeneric[T ~int64](db *sql.DB, a T) {
 	rows, _ := db.Query("select id from tb") // want "rows.Err\\(\\) must be called"
 	for rows.Next() {
 		// Handle row.
 	}
 }
 
-func NotCheckedGenericDefer[T ~int64](db *sql.DB, a T) {
+func NotCalledGenericDefer[T ~int64](db *sql.DB, a T) {
 	rows, _ := db.Query("select id from tb") // want "rows.Err\\(\\) must be called"
 	for rows.Next() {
 		// Handle row.

--- a/pkg/uncalled/testdata/database/sql/rows/err/not_called_notassigned.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/not_called_notassigned.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"

--- a/pkg/uncalled/testdata/database/sql/rows/err/not_called_var.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/not_called_var.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-func RowsErrNotCheckedVar(db *sql.DB) {
+func RowsErrNotCalledVar(db *sql.DB) {
 	rows, _ := db.Query("select id from tb") // want "rows.Err\\(\\) must be called"
 	for rows.Next() {
 		// Handle row.

--- a/pkg/uncalled/testdata/database/sql/rows/err/not_called_vars.go
+++ b/pkg/uncalled/testdata/database/sql/rows/err/not_called_vars.go
@@ -1,4 +1,4 @@
-package a
+package uncalled_test
 
 import (
 	"database/sql"
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-func NotCheckedVars(db *sql.DB) {
+func NotCalledVars(db *sql.DB) {
 	rows, err := db.Query("") // want "rows.Err\\(\\) must be called"
 	for rows.Next() {
 		// Handle row.

--- a/pkg/uncalled/testdata/net/http/request/body/close/called.go
+++ b/pkg/uncalled/testdata/net/http/request/body/close/called.go
@@ -1,0 +1,21 @@
+package uncalled_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func Called() {
+	resp, err := http.Get("http://example.com/")
+	if err != nil {
+		// Handle error.
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// Handle error.
+	}
+	fmt.Println(string(body))
+}

--- a/pkg/uncalled/testdata/net/http/request/body/close/not_called.go
+++ b/pkg/uncalled/testdata/net/http/request/body/close/not_called.go
@@ -1,0 +1,20 @@
+package uncalled_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func NotCalled() {
+	resp, err := http.Get("http://example.com/") // want "resp.Body.Close\\(\\) must be called"
+	if err != nil {
+		// Handle error.
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// Handle error.
+	}
+	fmt.Println(string(body))
+}


### PR DESCRIPTION
Add support for net/http.Response.Body Close check.

This includes reworking the call checks so they support more than one level of in expect.method.

Also:
* Fix race when used with analysistest with multiple patterns as that runs tests in parallel.
* Add logging support.
* Renamed tests to an extensible naming convention.