### PR TITLE
fix: return a config copy

### DIFF
--- a/pkg/uncalled/config.go
+++ b/pkg/uncalled/config.go
@@ -18,10 +18,10 @@ const (
 //go:embed .uncalled.yaml
 var defaultConfig []byte
 
-// DefaultConfig returns the default embedded configuration.
-func DefaultConfig() *Config {
-	c := &Config{}
-	yaml.Unmarshal(defaultConfig, c) //nolint: errcheck
+// DefaultConfig returns a copy of the default embedded configuration.
+func DefaultConfig() Config {
+	c := Config{}
+	yaml.Unmarshal(defaultConfig, &c) //nolint: errcheck
 	return c
 }
 


### PR DESCRIPTION
Return a copy of the config which is how golangci-lint expects its configurations.