### PR TITLE
ci: fix golangci-lint version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go: [1.19]
-        golangcli: [1.50.1]
+        golangcli: [v1.50.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fix the version used for golangci-lint due to typo in the matrix.