### PR TITLE
ci: bump go and golangci-lint version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,8 +14,8 @@ jobs:
   go:
     strategy:
       matrix:
-        go: [1.19]
-        golangcli: [v1.50.1]
+        go: [1.21]
+        golangcli: [v1.54.2]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}
@@ -35,22 +35,11 @@ jobs:
           go mod tidy
           git --no-pager diff && [[ 0 -eq $(git status --porcelain | wc -l) ]]
 
-      - name: Go Lint Standard
-        if: runner.os != 'Windows'
+      - name: Go Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: ${{ matrix.golangcli }}
-          args: "--out-${NO_FUTURE}format colored-line-number"
-          skip-cache: true
-
-      - name: Go Lint Windows
-        if: runner.os == 'Windows'
-        uses: golangci/golangci-lint-action@v3
-        env:
-          outformat: out-format
-        with:
-          version: ${{ matrix.golangcli }}
-          args: "--%outformat% colored-line-number"
+          args: --out-format=colored-line-number
           skip-cache: true
 
       - name: Go Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ linters:
     - nosnakecase
     - deadcode
     - varcheck
+    # Disabled because they are add no value or result in false positives.
+    - depguard
+    - musttag
 
 issues:
   max-same-issues: 0

--- a/pkg/uncalled/config.go
+++ b/pkg/uncalled/config.go
@@ -48,7 +48,7 @@ func loadDefaultConfig() (*Config, error) {
 // Config represents the configuration for uncalled Analyzer.
 type Config struct {
 	// DisableAll disables all rules.
-	DisableAll bool `yaml:"disable-all" mapstructure:"disable-all"`
+	DisableAll bool `mapstructure:"disable-all" yaml:"disable-all"`
 
 	// Disabled disables the given rules.
 	Disabled []string


### PR DESCRIPTION
Bump go and golangci-lint versions to the latest.

Also:
* Minor fixes to satisfy linters and disabling some which don't add value.
* Switch to args for golangci-lint-action now it's fixed.